### PR TITLE
[new release] get-activity (2 packages) (2.0.0)

### DIFF
--- a/packages/get-activity-lib/get-activity-lib.2.0.0/opam
+++ b/packages/get-activity-lib/get-activity-lib.2.0.0/opam
@@ -1,0 +1,43 @@
+opam-version: "2.0"
+synopsis: "Collect activity as markdown"
+maintainer: ["Guillaume Petiot <guillaume@tarides.com>"]
+authors: ["talex5@gmail.com"]
+homepage: "https://github.com/tarides/get-activity"
+bug-reports: "https://github.com/tarides/get-activity/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "alcotest" {with-test}
+  "ppx_expect" {with-test}
+  "astring"
+  "curly"
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "ppx_yojson_conv"
+  "yojson" {>= "1.6"}
+  "ocaml" {>= "4.08"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/get-activity.git"
+url {
+  src:
+    "https://github.com/tarides/get-activity/releases/download/2.0.0/get-activity-2.0.0.tbz"
+  checksum: [
+    "sha256=81126cfee494a96f6d25e931112cd8d75f0940af40c95f411c644d86a6bcbda2"
+    "sha512=6844c49cd671654420f34e77cefa783092b088dfb34376a4424b872925439922bec294d336a3c109681ed7155beb96d2716e4551c10c05d232fdc8ae79336c3f"
+  ]
+}
+x-commit-hash: "c3865ada8eeac490a79ca32f3d887604f7822a1c"

--- a/packages/get-activity/get-activity.2.0.0/opam
+++ b/packages/get-activity/get-activity.2.0.0/opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+synopsis: "Collect activity as markdown"
+maintainer: ["Guillaume Petiot <guillaume@tarides.com>"]
+authors: ["talex5@gmail.com"]
+homepage: "https://github.com/tarides/get-activity"
+bug-reports: "https://github.com/tarides/get-activity/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "cmdliner" {>= "1.1.1"}
+  "dune-build-info"
+  "fmt"
+  "logs"
+  "get-activity-lib" {= version}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/get-activity.git"
+url {
+  src:
+    "https://github.com/tarides/get-activity/releases/download/2.0.0/get-activity-2.0.0.tbz"
+  checksum: [
+    "sha256=81126cfee494a96f6d25e931112cd8d75f0940af40c95f411c644d86a6bcbda2"
+    "sha512=6844c49cd671654420f34e77cefa783092b088dfb34376a4424b872925439922bec294d336a3c109681ed7155beb96d2716e4551c10c05d232fdc8ae79336c3f"
+  ]
+}
+x-commit-hash: "c3865ada8eeac490a79ca32f3d887604f7822a1c"


### PR DESCRIPTION
Collect activity as markdown

- Project page: <a href="https://github.com/tarides/get-activity">https://github.com/tarides/get-activity</a>

##### CHANGES:

### Fixed

- Take into account the end date of the specified period when filtering github activity (tarides/get-activity#31, @gpetiot)

### Changed

- API: `Contributions.of_json` parameter `~from` is replaced by `~period` (tarides/get-activity#31, @gpetiot)
- Distinguish between issue comments and PR comments (tarides/get-activity#38, @gpetiot)
  API: new constructor `Comment` replacing `Issue_comment`

### Added

- Display curl requests and responses in debug mode (`-vv` or `--verbosity debug`) (tarides/get-activity#36, @gpetiot)
- Add the PR merge events to the contributions (tarides/get-activity#37, @emillon, @gpetiot)
  API: new constructor `Merge`
