### PR TITLE
[new release] okra (2 packages) (0.5.0)

### DIFF
--- a/packages/okra-lib/okra-lib.0.5.0/opam
+++ b/packages/okra-lib/okra-lib.0.5.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Report parsing prototypes"
+description: "A library of tools for report parsing"
+maintainer: ["Guillaume Petiot <guillaume@tarides.com>"]
+authors: ["Magnus Skjegstad"]
+license: "ISC"
+homepage: "https://github.com/tarides/okra"
+bug-reports: "https://github.com/tarides/okra/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.10"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.9.0"}
+  "xdg"
+  "get-activity-lib" {>= "2.0.1" & < "3.0.0"}
+  "gitlab" {>= "0.1.7"}
+  "calendar" {>= "3.0.0"}
+  "csv" {>= "2.4"}
+  "re"
+  "omd" {>= "2.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/okra.git"
+url {
+  src:
+    "https://github.com/tarides/okra/releases/download/0.5.0/okra-0.5.0.tbz"
+  checksum: [
+    "sha256=8fd9af33155a2f387038a0502960212e6d92b421d4eae6e47d424d6e121f2d34"
+    "sha512=3d3cf01505556c69ce2bac28e6dce6219e271433e2f4d4b20c9e5396f94c7d26f9b78b3cc4ff4a02760b6726587295a3d105f2e816e365174f6aa44daa04d9fd"
+  ]
+}
+x-commit-hash: "0ae4f4f85316f12229162daf881dddd4f8c3f80b"

--- a/packages/okra/okra.0.5.0/opam
+++ b/packages/okra/okra.0.5.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Report parsing executable"
+description: "An executable to be used for report parsing"
+maintainer: ["Guillaume Petiot <guillaume@tarides.com>"]
+authors: ["Magnus Skjegstad"]
+license: "ISC"
+homepage: "https://github.com/tarides/okra"
+bug-reports: "https://github.com/tarides/okra/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "mdx" {>= "2.2.1" & with-test}
+  "logs" {>= "0.7.0"}
+  "xdg"
+  "fmt" {>= "0.9.0"}
+  "okra-lib" {= version}
+  "cmdliner" {>= "1.1.1"}
+  "ppx_deriving_yaml" {>= "0.2.0"}
+  "bos"
+  "dune-build-info"
+  "yaml" {>= "3.0"}
+  "cohttp-lwt-unix" {>= "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/okra.git"
+url {
+  src:
+    "https://github.com/tarides/okra/releases/download/0.5.0/okra-0.5.0.tbz"
+  checksum: [
+    "sha256=8fd9af33155a2f387038a0502960212e6d92b421d4eae6e47d424d6e121f2d34"
+    "sha512=3d3cf01505556c69ce2bac28e6dce6219e271433e2f4d4b20c9e5396f94c7d26f9b78b3cc4ff4a02760b6726587295a3d105f2e816e365174f6aa44daa04d9fd"
+  ]
+}
+x-commit-hash: "0ae4f4f85316f12229162daf881dddd4f8c3f80b"


### PR DESCRIPTION
Report parsing executable

- Project page: <a href="https://github.com/tarides/okra">https://github.com/tarides/okra</a>

##### CHANGES:

### Changed

- Lint: fail if the placeholder text "Work Item 1" is still present in the report (tarides/okra#221, @gpetiot)
- Lint: check that the total of days reported for each engineer is 5 days (tarides/okra#178, @gpetiot)
- No special treatment for "OKR Updates" sections in reports (tarides/okra#211, @gpetiot)
- Lookup okr-db in the repo directory (set by `--repo-dir`/`-C`) if `--okr-db` is not set (tarides/okra#210, @gpetiot)
- Make github handles clickable in repo reports (tarides/okra#193, tarides/okra#207, @gpetiot)
- Parser collects all issues instead of raising an exception (tarides/okra#195, @gpetiot).
  Other commands that rely on parsing weekly reports (cat, team, stats) can now be run on reports that don't pass linting, but warnings are reported.
- Improve the "Invalid time" error messages (tarides/okra#199, @gpetiot)
- okra team lint: only print details of invalid/missing files, or total of valid files (tarides/okra#200, @gpetiot)
- okra gen report: PR/issue entries formatted the same way as in engineer reports (tarides/okra#201, @gpetiot)
- List of projects not printed by default anymore in generated reports (tarides/okra#212, @gpetiot).
  Use the new option `--print-projects` to display the list.
- okra gen: Group activity items together when possible (tarides/okra#208, @gpetiot).
  Comments are only listed when there is no other activity on the same issue/PR.

### Fixed

- Using an empty conf should not fail, better message in case of error (tarides/okra#192, @gpetiot)

### Added

- stats: Add option `--show-details` to print the details of the time per engineer (tarides/okra#220, @gpetiot)
- Add `ocaml-re` dependency instead of using `str` (tarides/okra#198, @gpetiot)

### Removed

- Remove options `--include-categories` and `--include-reports` (tarides/okra#215, @gpetiot)
