### PR TITLE
[new release] okra (2 packages) (1.0.0)

### DIFF
--- a/packages/okra-lib/okra-lib.1.0.0/opam
+++ b/packages/okra-lib/okra-lib.1.0.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Report parsing prototypes"
+description: "A library of tools for report parsing"
+maintainer: ["Guillaume Petiot <guillaume@tarides.com>"]
+authors: ["Magnus Skjegstad"]
+license: "ISC"
+homepage: "https://github.com/tarides/okra"
+bug-reports: "https://github.com/tarides/okra/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "ocaml" {>= "4.10"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "logs" {>= "0.7.0"}
+  "fmt" {>= "0.9.0"}
+  "xdg"
+  "get-activity-lib" {>= "2.0.1" & < "3.0.0"}
+  "gitlab" {>= "0.1.7"}
+  "calendar" {>= "3.0.0"}
+  "csv" {>= "2.4"}
+  "re"
+  "omd" {>= "2.0.0~alpha3"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/okra.git"
+url {
+  src:
+    "https://github.com/tarides/okra/releases/download/1.0.0/okra-1.0.0.tbz"
+  checksum: [
+    "sha256=289a72fdcabb221c86ae2a79b198d38abff682158a67445ad365758f930f8a0f"
+    "sha512=ea66c885f4be790bc08e70d143368d8f61a1f2bcd03703031c81306f6063cf98d5d8dd3bbe41e0800b2f9112461b52e1e824b2b9868a144e145d1577b8a44fe3"
+  ]
+}
+x-commit-hash: "2f8086b47d28299e68dc4f74e27b7a10e4e645f1"

--- a/packages/okra/okra.1.0.0/opam
+++ b/packages/okra/okra.1.0.0/opam
@@ -1,0 +1,48 @@
+opam-version: "2.0"
+synopsis: "Report parsing executable"
+description: "An executable to be used for report parsing"
+maintainer: ["Guillaume Petiot <guillaume@tarides.com>"]
+authors: ["Magnus Skjegstad"]
+license: "ISC"
+homepage: "https://github.com/tarides/okra"
+bug-reports: "https://github.com/tarides/okra/issues"
+depends: [
+  "dune" {>= "3.2"}
+  "alcotest" {>= "1.7.0" & with-test}
+  "mdx" {>= "2.2.1" & with-test}
+  "logs" {>= "0.7.0"}
+  "xdg"
+  "fmt" {>= "0.9.0"}
+  "okra-lib" {= version}
+  "cmdliner" {>= "1.1.1"}
+  "ppx_deriving_yaml" {>= "0.2.0"}
+  "bos"
+  "dune-build-info"
+  "yaml" {>= "3.0"}
+  "cohttp-lwt-unix" {>= "5.0.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/okra.git"
+url {
+  src:
+    "https://github.com/tarides/okra/releases/download/1.0.0/okra-1.0.0.tbz"
+  checksum: [
+    "sha256=289a72fdcabb221c86ae2a79b198d38abff682158a67445ad365758f930f8a0f"
+    "sha512=ea66c885f4be790bc08e70d143368d8f61a1f2bcd03703031c81306f6063cf98d5d8dd3bbe41e0800b2f9112461b52e1e824b2b9868a144e145d1577b8a44fe3"
+  ]
+}
+x-commit-hash: "2f8086b47d28299e68dc4f74e27b7a10e4e645f1"


### PR DESCRIPTION
Report parsing executable

- Project page: <a href="https://github.com/tarides/okra">https://github.com/tarides/okra</a>

##### CHANGES:

### Changed

- Lint: activity is now checked against objectives instead of workitems (tarides/okra#218, @gpetiot)
- Cat/Aggregate: generated reports use objectives instead of workitems (tarides/okra#218, @gpetiot)
- Use standardized categories for reporting non-engineering work time: Community, Hack, Learning, Leave, Management, Meet and Onboard (tarides/okra#230, @gpetiot)
- Lint: check the quarter of workitems instead of their status (tarides/okra#228, @gpetiot)
- Normalize error messages (tarides/okra#237, tarides/okra#239, @gpetiot)

### Added

- Allow engineers to specify the number of working days (tarides/okra#232, @patricoferris)
- Check that [--engineer] and [--team] are not both true (tarides/okra#233, @gpetiot)
- Gen: add example entries for standardized categories (tarides/okra#236, @gpetiot)
