### PR TITLE
[new release] caretaker (0.1.0)

### DIFF
--- a/packages/caretaker/caretaker.0.1.0/opam
+++ b/packages/caretaker/caretaker.0.1.0/opam
@@ -1,0 +1,47 @@
+opam-version: "2.0"
+synopsis: "Taking care of our technical projects"
+description:
+  "A tool to interface with the different sources we use for project management."
+maintainer: ["Tarides"]
+authors: ["Thomas Gazagnaire"]
+license: "ISC"
+homepage: "https://github.com/tarides/caretaker"
+bug-reports: "https://github.com/tarides/caretaker/issues"
+depends: [
+  "dune" {>= "3.7"}
+  "cohttp-lwt-unix"
+  "yojson"
+  "cmdliner"
+  "csv"
+  "conduit-lwt-unix"
+  "lwt_ssl"
+  "okra-lib" {>= "3.0.0" & < "4.0.0"}
+  "omd" {>= "2.0.0~alpha4"}
+  "calendar"
+  "alcotest" {with-test}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/tarides/caretaker.git"
+url {
+  src:
+    "https://github.com/tarides/caretaker/releases/download/0.1.0/caretaker-0.1.0.tbz"
+  checksum: [
+    "sha256=be12afe450fa04561b994cf68395a814d5ad455bb2a8199b3a9d157457155fb4"
+    "sha512=da0d15769c292d333cc9dfb975e97499f17cbba405b009be24668239837444062745831f2502c029f504e4b01b27baa58f199023a5156f29d7b54a9fe537a93b"
+  ]
+}
+x-commit-hash: "8491d3c319ad5da6154c86c88f8a4ff0055a4985"


### PR DESCRIPTION
Taking care of our technical projects

- Project page: <a href="https://github.com/tarides/caretaker">https://github.com/tarides/caretaker</a>

##### CHANGES:

### Changed

- Sort timesheet output (tarides/caretaker#80, @gpetiot)
- Add more debug information to debug rate-limiting errors (tarides/caretaker#75, @samoht)
- Depend on okra-lib.3.0.0 (tarides/caretaker#56, tarides/caretaker#65, tarides/caretaker#68, tarides/caretaker#82, @gpetiot)

### Fixed

- Fetch: fix the source for timesheets when okr-update-dir or admin-dir is specified (tarides/caretaker#69 , @gpetiot)

(changes before May '24 not tracked)
