### PR TITLE
Add a package for the development version of `dune`

### DIFF
--- a/packages/dune/dune.4.0~dev/opam
+++ b/packages/dune/dune.4.0~dev/opam
@@ -1,0 +1,78 @@
+opam-version: "2.0"
+name: "dune"
+synopsis: "Fast, portable, and opinionated build system"
+description: """\
+Dune is a build system that was designed to simplify the release of
+Jane Street packages. It reads metadata from "dune" files following a
+very simple s-expression syntax.
+
+Dune is fast, has very low-overhead, and supports parallel builds on
+all platforms. It has no system dependencies; all you need to build
+dune or packages using dune is OCaml. You don't need make or bash
+as long as the packages themselves don't use bash explicitly.
+
+Dune is composable; supporting multi-package development by simply
+dropping multiple repositories into the same directory.
+
+Dune also supports multi-context builds, such as building against
+several opam roots/switches simultaneously. This helps maintaining
+packages across several versions of OCaml and gives cross-compilation
+for free."""
+maintainer: "Jane Street Group, LLC <opensource@janestreet.com>"
+authors: "Jane Street Group, LLC <opensource@janestreet.com>"
+license: "MIT"
+homepage: "https://github.com/ocaml/dune"
+doc: "https://dune.readthedocs.io/"
+bug-reports: "https://github.com/ocaml/dune/issues"
+depends: [
+  "ocaml" {>= "4.08"}
+  "base-unix"
+  "base-threads"
+  "lwt" {with-dev-setup & os != "win32"}
+  "cinaps" {with-dev-setup}
+  "csexp" {with-dev-setup & >= "1.3.0"}
+  "js_of_ocaml" {with-dev-setup & >= "6.0.1" & os != "win32"}
+  "js_of_ocaml-compiler" {with-dev-setup & >= "6.0.1" & os != "win32"}
+  "mdx" {with-dev-setup & >= "2.3.0" & os != "win32"}
+  "menhir" {with-dev-setup & os != "win32"}
+  "ocamlfind" {with-dev-setup & os != "win32"}
+  "odoc" {with-dev-setup & >= "2.4.0" & os != "win32"}
+  "ppx_expect" {with-dev-setup & >= "v0.17" & os != "win32"}
+  "ppx_inline_test" {with-dev-setup & os != "win32"}
+  "ppxlib" {with-dev-setup & >= "0.35.0" & os != "win32"}
+  "ctypes" {with-dev-setup & os != "win32"}
+  "utop" {with-dev-setup & >= "2.6.0" & os != "win32"}
+  "melange" {with-dev-setup & >= "5.0.0-51" & os != "win32"}
+]
+conflicts: [
+  "merlin" {< "3.4.0"}
+  "ocaml-lsp-server" {< "1.3.0"}
+  "dune-configurator" {< "2.3.0"}
+  "odoc" {< "2.0.1"}
+  "dune-release" {< "1.3.0"}
+  "js_of_ocaml-compiler" {< "3.6.0"}
+  "jbuilder" {= "transition"}
+]
+build: [
+  [
+    "sh"
+    "-c"
+    "echo \"(version 4.0~dev+$(git rev-parse HEAD))\" >> dune-project"
+  ]
+  ["./configure" "--pkg-build-progress" "enable" "--lock-dev-tool" "enable"]
+  ["ocaml" "boot/bootstrap.ml" "-j" jobs]
+  [
+    "./_boot/dune.exe"
+    "build"
+    "dune.install"
+    "--release"
+    "--profile"
+    "dune-bootstrap"
+    "-j"
+    jobs
+  ]
+]
+dev-repo: "git+https://github.com/ocaml/dune.git"
+url {
+  src: "git+https://github.com/ocaml/dune.git"
+}


### PR DESCRIPTION
This PR proposes to add the latest version of `dune` with the experimental features enabled, in a similar way to OCaml `trunk` packages, to streamline its testing.