### PR TITLE
Add fpath as a dependency of okra-lib

### DIFF
--- a/packages/okra-lib/okra-lib.3.1.0/opam
+++ b/packages/okra-lib/okra-lib.3.1.0/opam
@@ -12,6 +12,7 @@ depends: [
   "alcotest" {>= "1.7.0" & with-test}
   "logs" {>= "0.7.0"}
   "fmt" {>= "0.9.0"}
+  "fpath"
   "xdg"
   "get-activity-lib" {>= "2.0.1" & < "3.0.0"}
   "gitlab" {>= "0.1.7"}


### PR DESCRIPTION
Fixes using `okra-lib` as a dependency with `dune pkg` while we wait for a new release of okra.

Fixed upstream on tarides/okra@5b8e68b.